### PR TITLE
Fixed issue #4

### DIFF
--- a/src/AlertMe.cpp
+++ b/src/AlertMe.cpp
@@ -26,7 +26,7 @@ const char PROGMEM b64_alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 char EMAIL_LOGIN[40];
 char EMAIL_PASSWORD[40];
 uint16_t smtp_port = 0;
-char* smtp_server = "";
+char smtp_server[40];
 bool needs_save = false;
 bool alert_debug = false;
 char* last_error = "";


### PR DESCRIPTION
This is my proposed fix for issue #4 which causes URL redirection to become corrupted. I fixed it by allocating memory to the `smtp_server` variable, which was being initialized to an empty string. When the domain is copied to `smtp_server` is overwrites the memory after it, which is what causes the corruption. By allocating a fixed amount of memory to it we can prevent this.