### PR TITLE
Enable Library Manager installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Don't use this for spam. *Don't you do it.*
 ----------
 # Installation
 
-~~**With Arduino Library Manager:**~~ **Coming soon!**
+**With Arduino Library Manager:**
 
-~~1. Open *Sketch > Include Library > Manage Libraries* in the Arduino IDE.~~  
-~~2. Search for "Volume", (look for "Connor Nishijima") and select the latest version.~~  
-~~3. Click the Install button and Arduino will prepare the library and examples for you!~~  
+1. Open *Sketch > Include Library > Manage Libraries* in the Arduino IDE.
+2. Search for "AlertMe", (look for "Connor Nishijima") and select the latest version.
+3. Click the Install button and Arduino will prepare the library and examples for you!
 
 **Manual Install:**
 


### PR DESCRIPTION
The library is now in the Arduino Library Manager, and thus these instructions can be un-struck out.